### PR TITLE
support recursive input directory searches

### DIFF
--- a/get_sql.py
+++ b/get_sql.py
@@ -27,8 +27,8 @@ shutil.rmtree(rpt_fldr, ignore_errors=True)
 rpt_fldr.mkdir(exist_ok=True)
 
 # copy in reports
-for report in Path(RTPSRC).glob("*.rpt"):
-    shutil.copyfile(RTPSRC + report.name, str(rpt_fldr / report.name))
+for report in Path(RTPSRC).glob("**/*.rpt"):
+    shutil.copyfile(report, str(rpt_fldr / report.name))
 
 # remove xml folder
 shutil.rmtree(xml_fldr, ignore_errors=True)


### PR DESCRIPTION
Update the glob pattern that searches for .rpt files to search recursively, and use the full report path instead of RTPSRC + report.name